### PR TITLE
Case-sensitive searching by document number, master record ID, master record name

### DIFF
--- a/GP.TransactionSearch/Controller.cs
+++ b/GP.TransactionSearch/Controller.cs
@@ -150,6 +150,20 @@ namespace GP.TransactionSearch
                     Controller.instance.Model.PMVendorLabel = string.Empty;
                 }
 
+                if (configSection.Settings.Get("DefaultDatesFromUserDate").Value != null && (!string.IsNullOrEmpty(configSection.Settings.Get("DefaultDatesFromUserDate").Value.ValueXml.InnerText)))
+                {
+                    success = bool.TryParse(configSection.Settings.Get("DefaultDatesFromUserDate").Value.ValueXml.InnerText, out boolSetting);
+
+                    if (success)
+                    {
+                        Controller.instance.Model.DefaultDatesFromUserDate = Convert.ToBoolean(configSection.Settings.Get("DefaultDatesFromUserDate").Value.ValueXml.InnerText);
+                    }
+                    else
+                    {
+                        Controller.instance.Model.DefaultDatesFromUserDate = false;
+                    }
+                }
+
                 return true;
 
             }

--- a/GP.TransactionSearch/Model.cs
+++ b/GP.TransactionSearch/Model.cs
@@ -33,5 +33,6 @@ namespace GP.TransactionSearch
 
         public bool SOPSearchFocus { get; set; }
 
+        public bool DefaultDatesFromUserDate { get; set; }
     }
 }

--- a/GP.TransactionSearch/PMTransactionSearch.Designer.cs
+++ b/GP.TransactionSearch/PMTransactionSearch.Designer.cs
@@ -107,6 +107,7 @@
             // 
             // txtVendorID
             // 
+            this.txtVendorID.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
             this.txtVendorID.Location = new System.Drawing.Point(276, 8);
             this.txtVendorID.Name = "txtVendorID";
             this.txtVendorID.Size = new System.Drawing.Size(97, 20);
@@ -150,6 +151,7 @@
             // 
             // txtDocNumber
             // 
+            this.txtDocNumber.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
             this.txtDocNumber.Location = new System.Drawing.Point(459, 7);
             this.txtDocNumber.Name = "txtDocNumber";
             this.txtDocNumber.Size = new System.Drawing.Size(89, 20);

--- a/GP.TransactionSearch/PMTransactionSearch.cs
+++ b/GP.TransactionSearch/PMTransactionSearch.cs
@@ -43,7 +43,15 @@ namespace GP.TransactionSearch
                 this.tsmViewMaster.Text = "View " + Controller.Instance.Model.PMVendorLabel;
             }
 
-            this.dateStart.Value = DateTime.Today.AddYears(-1);
+            if (Controller.Instance.Model.DefaultDatesFromUserDate)
+            {
+                this.dateEnd.Value = Dynamics.Globals.UserDate;
+                this.dateStart.Value = this.dateEnd.Value.AddYears(-1);
+            }
+            else
+            {
+                this.dateStart.Value = DateTime.Today.AddYears(-1);
+            }
 
             PrepDataGrid();
 

--- a/GP.TransactionSearch/Properties/Settings.Designer.cs
+++ b/GP.TransactionSearch/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace GP.TransactionSearch.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -55,6 +55,18 @@ namespace GP.TransactionSearch.Properties {
             }
             set {
                 this["RMCustomerLabel"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public string DefaultDatesFromUserDate {
+            get {
+                return ((string)(this["DefaultDatesFromUserDate"]));
+            }
+            set {
+                this["DefaultDatesFromUserDate"] = value;
             }
         }
     }

--- a/GP.TransactionSearch/Properties/Settings.settings
+++ b/GP.TransactionSearch/Properties/Settings.settings
@@ -11,5 +11,8 @@
     <Setting Name="RMCustomerLabel" Type="System.String" Scope="User">
       <Value Profile="(Default)">Customer</Value>
     </Setting>
+    <Setting Name="DefaultDatesFromUserDate" Type="System.String" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/GP.TransactionSearch/RMTransactionSearch.Designer.cs
+++ b/GP.TransactionSearch/RMTransactionSearch.Designer.cs
@@ -107,6 +107,7 @@
             // 
             // txtMasterID
             // 
+            this.txtMasterID.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
             this.txtMasterID.Location = new System.Drawing.Point(285, 8);
             this.txtMasterID.Name = "txtMasterID";
             this.txtMasterID.Size = new System.Drawing.Size(97, 20);
@@ -150,6 +151,7 @@
             // 
             // txtDocNumber
             // 
+            this.txtDocNumber.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
             this.txtDocNumber.Location = new System.Drawing.Point(488, 7);
             this.txtDocNumber.Name = "txtDocNumber";
             this.txtDocNumber.Size = new System.Drawing.Size(89, 20);

--- a/GP.TransactionSearch/RMTransactionSearch.cs
+++ b/GP.TransactionSearch/RMTransactionSearch.cs
@@ -48,7 +48,15 @@ namespace GP.TransactionSearch
                 this.Text = this.Text + " v" + Controller.Instance.Model.AssemblyVersion;
             }
 
-            this.dateStart.Value = DateTime.Today.AddYears(-1);
+            if (Controller.Instance.Model.DefaultDatesFromUserDate)
+            {
+                this.dateEnd.Value = Dynamics.Globals.UserDate;
+                this.dateStart.Value = this.dateEnd.Value.AddYears(-1);
+            }
+            else
+            {
+                this.dateStart.Value = DateTime.Today.AddYears(-1);
+            }
 
             PrepDataGrid();
 

--- a/GP.TransactionSearch/SOPTransactionSearch.Designer.cs
+++ b/GP.TransactionSearch/SOPTransactionSearch.Designer.cs
@@ -109,6 +109,7 @@
             // 
             // txtMasterID
             // 
+            this.txtMasterID.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
             this.txtMasterID.Location = new System.Drawing.Point(279, 8);
             this.txtMasterID.Name = "txtMasterID";
             this.txtMasterID.Size = new System.Drawing.Size(97, 20);
@@ -152,6 +153,7 @@
             // 
             // txtDocNumber
             // 
+            this.txtDocNumber.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
             this.txtDocNumber.Location = new System.Drawing.Point(471, 7);
             this.txtDocNumber.Name = "txtDocNumber";
             this.txtDocNumber.Size = new System.Drawing.Size(89, 20);

--- a/GP.TransactionSearch/SOPTransactionSearch.cs
+++ b/GP.TransactionSearch/SOPTransactionSearch.cs
@@ -48,7 +48,15 @@ namespace GP.TransactionSearch
                 this.Text = this.Text + " v" + Controller.Instance.Model.AssemblyVersion;
             }
 
-            this.dateStart.Value = DateTime.Today.AddYears(-1);
+            if (Controller.Instance.Model.DefaultDatesFromUserDate)
+            {
+                this.dateEnd.Value = Dynamics.Globals.UserDate;
+                this.dateStart.Value = this.dateEnd.Value.AddYears(-1);
+            }
+            else
+            {
+                this.dateStart.Value = DateTime.Today.AddYears(-1);
+            }
 
             PrepDataGrid();
 

--- a/GP.TransactionSearch/SQL/csspPMTransactionSearch v1.1.sql
+++ b/GP.TransactionSearch/SQL/csspPMTransactionSearch v1.1.sql
@@ -83,7 +83,7 @@ FROM	(
 	 WHERE P.DOCDATE >= @StartDate AND P.DOCDATE <= @EndDate
 	 AND P.DOCNUMBR LIKE '%'+@DocNumber+'%'
 	 AND P.VENDORID LIKE '%'+@VendorID+'%'
-	 AND V.VENDNAME LIKE '%'+@VendorName+'%'
+	 AND upper(V.VENDNAME) LIKE '%'+upper(@VendorName)+'%'
 	 AND P.DOCAMNT >= @AmountFrom
 	 AND P.DOCAMNT <= @AmountTo
 	

--- a/GP.TransactionSearch/SQL/csspRMTransactionSearch v1.0.sql
+++ b/GP.TransactionSearch/SQL/csspRMTransactionSearch v1.0.sql
@@ -77,7 +77,7 @@ FROM	(
 	 WHERE R.DOCDATE >= @StartDate AND R.DOCDATE <= @EndDate
 	 AND R.DOCNUMBR LIKE '%'+@DocNumber+'%'
 	 AND R.CUSTNMBR LIKE '%'+@CustomerID+'%'
-	 AND C.CUSTNAME LIKE '%'+@CustomerName+'%'
+	 AND upper(C.CUSTNAME) LIKE '%'+upper(@CustomerName)+'%'
 	 AND R.ORTRXAMT >= @AmountFrom
 	 AND R.ORTRXAMT <= @AmountTo
 	

--- a/GP.TransactionSearch/SQL/csspSOPTransactionSearch v1.0.sql
+++ b/GP.TransactionSearch/SQL/csspSOPTransactionSearch v1.0.sql
@@ -101,7 +101,7 @@ EXEC dbo.csspSOPTransactionSearch @StartDate = '2017-01-01',
           AND sh.DOCDATE <= @EndDate
           AND sh.SOPNUMBE LIKE '%' + @DocNumber + '%'
           AND sh.CUSTNMBR LIKE '%' + @CustomerID + '%'
-          AND sh.CUSTNAME LIKE '%' + @CustomerName + '%'
+          AND upper(sh.CUSTNAME) LIKE '%' + upper(@CustomerName) + '%'
           AND sh.DOCAMNT >= @AmountFrom
           AND sh.DOCAMNT <= @AmountTo
 		  AND (sl.ITEMNMBR LIKE '%' + @ItemNumber + '%' OR sl.ITEMDESC LIKE '%' + @ItemDescr + '%')

--- a/GP.TransactionSearch/TransactionSearch.Designer.cs
+++ b/GP.TransactionSearch/TransactionSearch.Designer.cs
@@ -204,6 +204,7 @@
             // 
             // txtDocNumber
             // 
+            this.txtDocNumber.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
             this.txtDocNumber.Location = new System.Drawing.Point(459, 7);
             this.txtDocNumber.Name = "txtDocNumber";
             this.txtDocNumber.Size = new System.Drawing.Size(89, 20);
@@ -236,6 +237,7 @@
             // 
             // txtVendorID
             // 
+            this.txtVendorID.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper;
             this.txtVendorID.Location = new System.Drawing.Point(276, 8);
             this.txtVendorID.Name = "txtVendorID";
             this.txtVendorID.Size = new System.Drawing.Size(97, 20);

--- a/GP.TransactionSearch/TransactionSearch.cs
+++ b/GP.TransactionSearch/TransactionSearch.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Dexterity.Applications;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -39,7 +40,15 @@ namespace GP.TransactionSearch
                 this.Text = this.Text + " v" + Controller.Instance.Model.AssemblyVersion;
             }
 
-            this.dateStart.Value = DateTime.Today.AddYears(-1);
+            if (Controller.Instance.Model.DefaultDatesFromUserDate)
+            {
+                this.dateEnd.Value = Dynamics.Globals.UserDate;
+                this.dateStart.Value = this.dateEnd.Value.AddYears(-1);
+            }
+            else
+            {
+                this.dateStart.Value = DateTime.Today.AddYears(-1);
+            }
 
             PrepDataGrid();
 

--- a/GP.TransactionSearch/app.config
+++ b/GP.TransactionSearch/app.config
@@ -16,6 +16,9 @@
             <setting name="RMCustomerLabel" serializeAs="String">
                 <value>Customer</value>
             </setting>
+            <setting name="DefaultDatesFromUserDate" serializeAs="String">
+                <value>False</value>
+            </setting>
         </GP.TransactionSearch.Properties.Settings>
     </userSettings>
 </configuration>


### PR DESCRIPTION
Make searching by document number and master record ID (e.g. Customer ID / Vendor ID) work on a database that uses a case sensitive SQL collation (e.g. Latin1_General_BIN). This change was made to all three inquiry windows (RM, SOP, PM). See before and after screenshots below of the RM inquiry window.

**Before**:
![searchbycustomerid-casesensitive-before](https://user-images.githubusercontent.com/42712673/45267540-84394180-b423-11e8-9970-cc356e46c77c.png)

![searchbydocnum-casesensitive-before](https://user-images.githubusercontent.com/42712673/45267545-961ae480-b423-11e8-8a48-8880247ffa8c.png)

**After**:
![searchbycustomerid-casesensitive-after](https://user-images.githubusercontent.com/42712673/45267549-9fa44c80-b423-11e8-9ce4-ff8f8918ab23.png)

![searchbydocnum-casesensitive-after](https://user-images.githubusercontent.com/42712673/45267552-a8951e00-b423-11e8-9635-cf21622bf14b.png)
